### PR TITLE
Make sure to check out with pat when using the -cloneWithHttps option.

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,9 @@ The `organisation` and `project` parameters are properties of the Azure DevOps p
 A personal access token should be generated in Azure DevOps security settings. A Code/Read permission should be enough.
 
 An optional `-basePath <path>` parameter can be provided to customize cloning target directory.
-By default, SSH is used to clone the repositories. To use HTTPS, pass in the `cloneWithHttps` flag.
+By default, SSH is used to clone the repositories, and you need to make sure to have the right keys installed.
+
+To use HTTPS, pass in the `cloneWithHttps` flag. With `cloneWithHttps` the provided personal access token will be used to checkout the code. 
 
 ## update
 This scripts automates updating of repository contents using `git pull` command. Usage:

--- a/scripts/Clone-Repos.ps1
+++ b/scripts/Clone-Repos.ps1
@@ -22,6 +22,11 @@ $repos = ($reposResponse.Content | ConvertFrom-Json).value
 foreach ($repo in $repos) {
 	$repoPath = $repo."$repoPathProperty"
 	$repoLocation = "$basePath\$($repo.name)"
+
+	if ($cloneWithHttps) {
+		$repoPath = $repoPath.Replace("https://$($project)@","https://$($project):$($pat)@")
+	}
+
 	Write-Host "Cloning $($repo.name) from $repoPath into $repoLocation"
 	& 'git' 'clone' $repoPath $repoLocation
 

--- a/scripts/Clone-Repos.ps1
+++ b/scripts/Clone-Repos.ps1
@@ -23,7 +23,7 @@ foreach ($repo in $repos) {
 	$repoPath = $repo."$repoPathProperty"
 
 	if ($cloneWithHttps) {
-		$repoPath = $repoPath.Replace("https://$($project)@","https://$($project):$($pat)@")
+		$repoPath = $repoPath -replace "https://.*@", "https://$($pat):$($pat)@"
 	}
 
 	$repoLocation = Join-Path -Path $basePath -ChildPath $repo.name


### PR DESCRIPTION
I didn't have ssh configured for the new org I was using the script for and it failed on repo checkout. 

Since pat is provided, in case of https it is easy to use it to check out the code.